### PR TITLE
Update how to get pipelines for new kedro version

### DIFF
--- a/kedro_serving/cli.py
+++ b/kedro_serving/cli.py
@@ -21,6 +21,7 @@ def serving_commands():
 @click.option(
     "--pipeline",
     "-n",  # n for "name"
+    default="__default__",
     help="The name of the kedro pipeline to serve. Default to '__default__'",
 )
 @click.option(

--- a/kedro_serving/running_server.py
+++ b/kedro_serving/running_server.py
@@ -5,6 +5,7 @@ from typing import List, NamedTuple, Optional
 import numpy as np
 import pandas as pd
 from fastapi import FastAPI
+from kedro.framework.project import find_pipelines
 from kedro.framework.session import KedroSession
 from kedro.framework.startup import bootstrap_project
 from kedro.io import DataCatalog, MemoryDataSet
@@ -76,7 +77,7 @@ def init_app(
     with KedroSession.create(env=env, extra_params="") as session:
         runner = SequentialRunner()
         context = session.load_context()
-        pipeline = context.pipelines[pipeline_name]
+        pipeline = find_pipelines()[pipeline_name]
         catalog = context.catalog
 
     # TODO: make copy mode customisable!


### PR DESCRIPTION
## Description
Why was this PR created?
context.pipelines does not work in kedro 0.18

## Development notes
What have you changed, and how has this been tested?
changed to use new find_pipelines function, tested locally

## Checklist

- [ ] Read the [contributing](../CONTRIBUTING.md) guidelines
- [ ] Open this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Update the documentation to reflect the code changes
- [ ] Add a description of this change and add your name to the list of supporting contributions in the [`CHANGELOG.md`](../CHANGELOG.md) file. Please respect [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) guidelines.
- [ ] Add tests to cover your changes

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

- I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
- I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorised to submit this contribution on behalf of the original creator(s) or their licensees.
- I certify that the use of this contribution as authorised by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
